### PR TITLE
docs: fix typos in plotting helpers

### DIFF
--- a/R/MarkdownReports.R
+++ b/R/MarkdownReports.R
@@ -1345,7 +1345,7 @@ wboxplot <- function(yourlist,
 #'   work).
 #' @param percentage Display percentage instead of counts. TRUE by default.
 #' @param both_pc_and_value Report both percentage AND number.
-#' @param col Fill color. Defined by rich colours by default
+#' @param col Fill color. Defined by rich colors by default
 #' @param w Width of the saved pdf image, in inches.
 #' @param h Height of the saved pdf image, in inches.
 #' @param savefile Save plot as pdf in OutDir, TRUE by default.
@@ -1447,8 +1447,8 @@ wpie <- function(NamedVector,
 #' @param pchcex Define the size of the symbol for each data point.
 #' @param bg Background color.
 #' @param col Color of the plot.
-#' @param metod Method for displaying data points to avoid overlap; either"jitter" or "stack". See
-#'   stripchart().
+#' @param method Method for displaying data points to avoid overlap; either "jitter" or "stack".
+#'   See stripchart().
 #' @param jitter The amount of horizontal scatter added to the individual data points (to avoid
 #'   overlaps).
 #' @param tilted_text Use 45 degree x-labels if TRUE. Useful for long, but not too many labels.
@@ -1475,7 +1475,7 @@ wstripchart <- function(yourlist,
                         border = 1,
                         incrBottMarginBy = 0,
                         tilted_text = FALSE,
-                        metod = "jitter",
+                        method = "jitter",
                         jitter = 0.3,
                         pch = 18,
                         pchlwd = 1,
@@ -1537,7 +1537,7 @@ wstripchart <- function(yourlist,
     yourlist,
     vertical = TRUE,
     add = TRUE,
-    method = metod,
+    method = method,
     jitter = jitter,
     pch = pch,
     bg = bg_,
@@ -1600,8 +1600,8 @@ wstripchart <- function(yourlist,
 #' @param pch Define the symbol for each data point. A number (0-25) or any string between ""-s.
 #' @param pchlwd Define the outline width of the symbol for each data point.
 #' @param pchcex Define the size of the symbol for each data point.
-#' @param metod Method for displaying data points to avoid overlap; either"jitter" or "stack". See
-#'   stripchart().
+#' @param method Method for displaying data points to avoid overlap; either "jitter" or "stack".
+#'   See stripchart().
 #' @param jitter The amount of horizontal scatter added to the individual data points (to avoid
 #'   overlaps).
 #' @param incrBottMarginBy Increase the blank space at the bottom of the plot. Use if labels do not
@@ -1619,7 +1619,7 @@ wstripchart <- function(yourlist,
 #' wstripchart_list(
 #'   yourlist = my.ls, sub = NULL, ylab = NULL, xlab = NULL,
 #'   border = 1, bxpcol = 0, pch = 23, pchlwd = 1, pchcex = 1.5, bg = "chartreuse2", col = 1,
-#'   metod = jitter, jitter = 0.2, w = 7, incrBottMarginBy = 0, tilted_text = FALSE, mdlink = FALSE
+#'   method = jitter, jitter = 0.2, w = 7, incrBottMarginBy = 0, tilted_text = FALSE, mdlink = FALSE
 #' )
 wstripchart_list <- function(yourlist,
                              ...,
@@ -1636,7 +1636,7 @@ wstripchart_list <- function(yourlist,
                              tilted_text = FALSE,
                              bg = "chartreuse2",
                              col = "black",
-                             metod = "jitter",
+                             method = "jitter",
                              jitter = 0.2,
                              savefile = unless.specified("b.save.wplots"),
                              w = unless.specified("b.defSize"),
@@ -1873,12 +1873,12 @@ wvioplot_list <- function(yourlist,
 #' @param xlab X-axis label.
 #' @param ylab Y-axis label.
 #' @param pch Define the symbol for each data point. A number (0-25) or any string between ""-s.
-#' @param viocoll Background color of each individual violing plot.
-#' @param vioborder Border color of each individual violing plot.
+#' @param viocoll Background color of each individual violin plot.
+#' @param vioborder Border color of each individual violin plot.
 #' @param bg Background color.
 #' @param col Color of the plot.
-#' @param metod Method for displaying data points to avoid overlap; either"jitter" or "stack".
-#' See stripchart().
+#' @param method Method for displaying data points to avoid overlap; either "jitter" or "stack".
+#'   See stripchart().
 #' @param jitter The amount of horizontal scatter added to the individual
 #' data points (to avoid overlaps).
 #' @param incrBottMarginBy Increase the blank space at the bottom of the plot.
@@ -1896,7 +1896,7 @@ wvioplot_list <- function(yourlist,
 #' @examples try.dev.off()
 #' my.ls <- list(A = rnorm(10), B = rnorm(10), C = rnorm(10))
 #' # wviostripchart_list (yourlist = my.ls, pch = 23, viocoll = 0, vioborder = 1, sub = FALSE,
-#' # bg = 0, col = "black", metod = "jitter", jitter = 0.1, w = 7, mdlink = FALSE)
+#' # bg = 0, col = "black", method = "jitter", jitter = 0.1, w = 7, mdlink = FALSE)
 wviostripchart_list <- function(yourlist,
                                 ...,
                                 pch = 20,
@@ -1904,7 +1904,7 @@ wviostripchart_list <- function(yourlist,
                                 vioborder = 1,
                                 bg = 1,
                                 col = 1,
-                                metod = "jitter",
+                             method = "jitter",
                                 jitter = 0.25,
                                 main = as.character(substitute(yourlist)),
                                 sub = NULL,
@@ -1973,7 +1973,7 @@ wviostripchart_list <- function(yourlist,
         at = i,
         add = TRUE,
         vertical = TRUE,
-        method = metod,
+        method = method,
         jitter = jitter,
         pch = pch,
         bg = bg[[k]],

--- a/man/wpie.Rd
+++ b/man/wpie.Rd
@@ -27,7 +27,7 @@ wpie(
 
 \item{plotname}{Title of the plot (main parameter) and also the name of the file.}
 
-\item{col}{Fill color. Defined by rich colours by default}
+\item{col}{Fill color. Defined by rich colors by default}
 
 \item{savefile}{Save plot as pdf in OutDir, TRUE by default.}
 

--- a/man/wstripchart.Rd
+++ b/man/wstripchart.Rd
@@ -13,7 +13,7 @@ wstripchart(
   border = 1,
   incrBottMarginBy = 0,
   tilted_text = FALSE,
-  metod = "jitter",
+  method = "jitter",
   jitter = 0.3,
   pch = 18,
   pchlwd = 1,
@@ -54,7 +54,7 @@ fit on the plot.}
 
 \item{tilted_text}{Use 45 degree x-labels if TRUE. Useful for long, but not too many labels.}
 
-\item{metod}{Method for displaying data points to avoid overlap; either"jitter" or "stack". See
+\item{method}{Method for displaying data points to avoid overlap; either "jitter" or "stack". See
 stripchart().}
 
 \item{jitter}{The amount of horizontal scatter added to the individual data points (to avoid

--- a/man/wstripchart_list.Rd
+++ b/man/wstripchart_list.Rd
@@ -20,7 +20,7 @@ wstripchart_list(
   tilted_text = FALSE,
   bg = "chartreuse2",
   col = "black",
-  metod = "jitter",
+  method = "jitter",
   jitter = 0.2,
   savefile = unless.specified("b.save.wplots"),
   w = unless.specified("b.defSize"),
@@ -63,7 +63,7 @@ fit on the plot.}
 
 \item{col}{Color of the plot.}
 
-\item{metod}{Method for displaying data points to avoid overlap; either"jitter" or "stack". See
+\item{method}{Method for displaying data points to avoid overlap; either "jitter" or "stack". See
 stripchart().}
 
 \item{jitter}{The amount of horizontal scatter added to the individual data points (to avoid
@@ -92,6 +92,6 @@ my.ls <- list(A = rnorm(10), B = rnorm(10), C = rnorm(10))
 wstripchart_list(
   yourlist = my.ls, sub = NULL, ylab = NULL, xlab = NULL,
   border = 1, bxpcol = 0, pch = 23, pchlwd = 1, pchcex = 1.5, bg = "chartreuse2", col = 1,
-  metod = jitter, jitter = 0.2, w = 7, incrBottMarginBy = 0, tilted_text = FALSE, mdlink = FALSE
+  method = jitter, jitter = 0.2, w = 7, incrBottMarginBy = 0, tilted_text = FALSE, mdlink = FALSE
 )
 }

--- a/man/wviostripchart_list.Rd
+++ b/man/wviostripchart_list.Rd
@@ -12,7 +12,7 @@ wviostripchart_list(
   vioborder = 1,
   bg = 1,
   col = 1,
-  metod = "jitter",
+  method = "jitter",
   jitter = 0.25,
   main = as.character(substitute(yourlist)),
   sub = NULL,
@@ -34,15 +34,15 @@ function (most of them should work).}
 
 \item{pch}{Define the symbol for each data point. A number (0-25) or any string between ""-s.}
 
-\item{viocoll}{Background color of each individual violing plot.}
+\item{viocoll}{Background color of each individual violin plot.}
 
-\item{vioborder}{Border color of each individual violing plot.}
+\item{vioborder}{Border color of each individual violin plot.}
 
 \item{bg}{Background color.}
 
 \item{col}{Color of the plot.}
 
-\item{metod}{Method for displaying data points to avoid overlap; either"jitter" or "stack".
+\item{method}{Method for displaying data points to avoid overlap; either "jitter" or "stack".
 See stripchart().}
 
 \item{jitter}{The amount of horizontal scatter added to the individual
@@ -80,5 +80,5 @@ not to overwrite previous versions.
 try.dev.off()
 my.ls <- list(A = rnorm(10), B = rnorm(10), C = rnorm(10))
 # wviostripchart_list (yourlist = my.ls, pch = 23, viocoll = 0, vioborder = 1, sub = FALSE,
-# bg = 0, col = "black", metod = "jitter", jitter = 0.1, w = 7, mdlink = FALSE)
+# bg = 0, col = "black", method = "jitter", jitter = 0.1, w = 7, mdlink = FALSE)
 }


### PR DESCRIPTION
## Summary
- normalize color spelling and clarify violin plot descriptions
- correct method parameter spelling and examples across stripchart helpers

## Testing
- `R -q -e "devtools::document(); devtools::check()"` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_6893354fe5d8832cb8261efbc890ffa0