### PR TITLE
Fix typos in comments

### DIFF
--- a/MarkdownReports.LEGACY.VERSION.v3.1.1/R/MarkdownReports.R
+++ b/MarkdownReports.LEGACY.VERSION.v3.1.1/R/MarkdownReports.R
@@ -11,7 +11,7 @@
 # - Plots
 # - Plots for cycling over data frame columns or rows
 # - A4 pdfs for multi-plots
-# - Add-ons to exisiting plots
+# - Add-ons to existing plots
 # - Graphics
 # - Colors
 # - Printing to the markdown file and to the screen
@@ -95,7 +95,7 @@ setup_MarkdownReports <- function (OutDir = getwd(), scriptname = basename(OutDi
 # create_set_SubDir
 #'
 #' Create or set the output directory of the script, and set the "NewOutDir" variable that is used by all ~wplot functions. Opening pair of the create_set_Original_OutDir function.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @param makeOutDirOrig Change the "OutDirOrig" variable to the current OutDir (before setting it to a subdir).
 #' @param setDir Change working directory to the newly defined subdirectory
 #' @export
@@ -115,7 +115,7 @@ create_set_SubDir <- function (..., makeOutDirOrig=T, setDir=T) {
     iprint("OutDirOrig will be:", OutDir)
     assign("OutDirOrig", OutDir, envir = .GlobalEnv)
   } #if
-  iprint("Call *create_set_Original_OutDir()* when chaning back to the main dir.")
+  iprint("Call *create_set_Original_OutDir()* when changing back to the main dir.")
   assign("OutDir", NewOutDir, envir = .GlobalEnv)
   assign("b.Subdirname", b.Subdirname, envir = .GlobalEnv) # Flag that ww.MarkDown_Img_Logger_PDF_and_PNG uses
 }
@@ -123,7 +123,7 @@ create_set_SubDir <- function (..., makeOutDirOrig=T, setDir=T) {
 
 # create_set_Original_OutDir
 #'
-#' Closing pair of the create_set_SubDir function. Call when chaning back to the main dir. Set the output directory of the script, and set the "NewOutDir" variable that is used by all ~wplot functions.
+#' Closing pair of the create_set_SubDir function. Call when changing back to the main dir. Set the output directory of the script, and set the "NewOutDir" variable that is used by all ~wplot functions.
 #' @param NewOutDir The new OutDir
 #' @param NewPath_of_report  The new path_of_report
 #' @param setDir Change working directory to the newly defined subdirectory
@@ -162,7 +162,7 @@ continue_logging_markdown <- function (b.scriptname) {
 #' create_set_OutDir
 #'
 #' Create or set the output directory of the script, and set the "OutDir" variable that is used by all ~wplot functions.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @export
 #' @examples create_set_OutDir (... =  )
 
@@ -1073,7 +1073,7 @@ pdfA4plot_off <- function () {
 
 
 
-# Add-ons to exisiting plots -------------------------------------------------------------------------------------------------
+# Add-ons to existing plots -------------------------------------------------------------------------------------------------
 
 #' error_bar
 #'
@@ -1111,8 +1111,8 @@ error_bar <- function (x, y, upper, lower = upper, width  = 0.1, ...) {
 #' @param h Height of the saved pdf image, in inches.
 #' @param bty The type of box to be drawn around the legend. The allowed values are "o" (the default) and "n".
 #' @param title What should be the title of the legend? NULL by default
-#' @param ttl.by.varname Should the title of the legend substituted from the fill_ variable's name? FALSE by default. Does not work if you pass on a list item like this: list$element
-#' @param OverwritePrevPDF Save the plot immediately with the same name the last wplot* function made (It is stored in plotnameLastPlot variable).
+#' @param ttl.by.varname Should the title of the legend be substituted from the fill_ variable's name? FALSE by default. Does not work if you pass on a list item like this: list$element
+#' @param OverwritePrevPDF Save the plot immediately with the same name the last wplot* function made (It is stored in the plotnameLastPlot variable).
 #' @param mdlink Insert a .pdf and a .png image link in the markdown report, set by "path_of_report".
 #' @export
 #' @examples function(fill_ = NULL, poz=4, legend = names(fill_), ..., w=7, h=w, bty = "n", OverwritePrevPDF =T)
@@ -1148,8 +1148,8 @@ wlegend <- function(fill_ = NA, poz=4, legend, cex =.75, bty = "n", ..., w=7, h=
 #' @param h Height of the saved pdf image, in inches.
 #' @param bty The type of box to be drawn around the legend. The allowed values are "o" (the default) and "n".
 #' @param title What should be the title of the legend? NULL by default
-#' @param ttl.by.varname Should the title of the legend substituted from the fill_ variable's name? FALSE by default. Does not work if you pass on a list item like this: list$element
-#' @param OverwritePrevPDF Save the plot immediately with the same name the last wplot* function made (It is stored in plotnameLastPlot variable).
+#' @param ttl.by.varname Should the title of the legend be substituted from the fill_ variable's name? FALSE by default. Does not work if you pass on a list item like this: list$element
+#' @param OverwritePrevPDF Save the plot immediately with the same name the last wplot* function made (It is stored in the plotnameLastPlot variable).
 #' @param mdlink Insert a .pdf and a .png image link in the markdown report, set by "path_of_report".
 #' @export
 #' @examples function(legend = "Hey",poz=4, ..., w=7, h=w, bty = "n", OverwritePrevPDF =T)
@@ -1170,12 +1170,12 @@ wlegend.label <- function(legend = "...", poz=1, cex =1, bty = "n", ..., w=7, h=
 #' barplot_label
 #'
 #' Add extra labels to your bar plots at the top or the base.
-#' @param barplotted_variable The variable that you barplotted previously.
+#' @param barplotted_variable The variable that you previously bar plotted.
 #' @param labels Label text.
 #' @param bottom Put labels at the bottom of the bars.
-#' @param TopOffset Absolute offset from top.
-#' @param relpos_bottom Relative offset from bottom.
-#' @param OverwritePrevPDF Save the plot immediately with the same name the last wplot* function made (It is stored in plotnameLastPlot variable). Never inserts an mdlink.
+#' @param TopOffset Absolute offset from the top.
+#' @param relpos_bottom Relative offset from the bottom.
+#' @param OverwritePrevPDF Save the plot immediately with the same name the last wplot* function made (It is stored in the plotnameLastPlot variable). Never inserts an mdlink.
 #' @param ... Pass any other parameter of the corresponding text function (most of them should work).
 #' @export
 #' @examples barplot (1:10); barplot_label (1:10, labels =11:2  , bottom = F, TopOffset = 0.5, relpos_bottom = 0.1, ... =  )
@@ -1204,7 +1204,7 @@ barplot_label <- function (barplotted_variable, labels, bottom = F, TopOffset = 
 #' @param coeff What coefficient to display? Either "all", "pearson", "spearman" correlation values or "r2" for the Coefficient of Determination.
 #' @param textlocation where to put the legend?
 #' @param cex font size; 1 by default
-#' @param OverwritePrevPDF Save the plot immediately with the same name the last wplot* function made (It is stored in plotnameLastPlot variable). Never inserts an mdlink.
+#' @param OverwritePrevPDF Save the plot immediately with the same name the last wplot* function made (It is stored in the plotnameLastPlot variable). Never inserts an mdlink.
 #' @param ...  Additional parameters for the line to display.
 #' @export
 #' @examples x = cbind(a=rnorm(1:10), b=rnorm(10)); wplot(x); wLinRegression(x, coeff = c("pearson", "spearman", "r2"))
@@ -1406,7 +1406,7 @@ variable.or.path.exists <- function(path = path_of_report) {
 #' iprint
 #'
 #' A more intelligent printing function that collapses any variable passed to it by white spaces.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @export
 #' @examples iprint ("Hello ", "you ", 3, ", " , 11, " year old kids.")
 
@@ -1420,7 +1420,7 @@ any_print = iprint # for compatibility
 #' llprint
 #'
 #' Collapse by white spaces a sentence from any variable passed on to the function. Print the sentence to the screen and write it to your markdown report file, if the "path_of_report" variable is defined.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @export
 #' @examples llprint (... =  )
 
@@ -1435,7 +1435,7 @@ llprint <- function (...) {
 #' llogit
 #'
 #' Collapse by white spaces a sentence from any variable passed on to the function. llogit() writes it to your markdown report file, if the "path_of_report" variable is defined. It does not print the sentence to the screen.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @export
 #' @examples llogit (... =  )
 
@@ -1671,11 +1671,11 @@ md.LinkTable <- function(tableOfLinkswRownames) {
 #' Filter values that fall between above high-pass-threshold (X >).
 #' @param numeric_vector Values to be filtered.
 #' @param threshold A numeric value above which "numeric_vector" passes.
-#' @param passequal Pass if a value is larger, or equal than the threshold. FALSE by default.
+#' @param passequal Pass if a value is larger than or equal to the threshold. FALSE by default.
 #' @param prepend Text prepended to the results.
 #' @param return_survival_ratio Return a number with the survival ratio (TRUE), or a logical index vector of the survivors (FALSE).
 #' @param plot.hist Plot the histogram of the input data
-#' @param saveplot Save the histogram as PDF, FALSE by defeault
+#' @param saveplot Save the histogram as PDF, FALSE by default
 #' @param ... Additional arguments for the histogram
 #' @export
 #' @examples filter_HP (numeric_vector = rnorm(1000,6) , threshold = 5 , prepend = "From all values " , return_survival_ratio = F)
@@ -1696,11 +1696,11 @@ filter_HP <- function(numeric_vector, threshold, passequal = F, prepend =""
 #' Filter values that fall below the low-pass threshold (X <).
 #' @param numeric_vector Values to be filtered.
 #' @param threshold A numeric value below which "numeric_vector" passes.
-#' @param passequal Pass if a value is smaller, or equal than the threshold. FALSE by default.
+#' @param passequal Pass if a value is smaller than or equal to the threshold. FALSE by default.
 #' @param prepend Text prepended to the results.
 #' @param return_survival_ratio Return a number with the survival ratio (TRUE), or a logical index vector of the survivors (FALSE).
 #' @param plot.hist Plot the histogram of the input data
-#' @param saveplot Save the histogram as PDF, FALSE by defeault
+#' @param saveplot Save the histogram as PDF, FALSE by default
 #' @param ... Additional arguments for the histogram
 #' @export
 #' @examples filter_LP (numeric_vector = rnorm(1000,6) , threshold = 5 , prepend = "From all values " , return_survival_ratio = F)
@@ -1726,7 +1726,7 @@ filter_LP <- function(numeric_vector, threshold, passequal = F, prepend =""
 #' @param return_survival_ratio Return a number with the survival ratio (TRUE), or a logical index vector of the survivors (FALSE).
 #' @param EdgePass If TRUE, it reverses the filter: everything passes except between the two thresholds.
 #' @param plot.hist Plot the histogram of the input data
-#' @param saveplot Save the histogram as PDF, FALSE by defeault
+#' @param saveplot Save the histogram as PDF, FALSE by default
 #' @param ... Additional arguments for the histogram
 #' @export
 #' @examples filter_MidPass (numeric_vector = rnorm(1000,6)  , HP_threshold = 4 , LP_threshold =8  , prepend = "From all values " , return_survival_ratio = FALSE, EdgePass = T)
@@ -1765,7 +1765,7 @@ iround <- function (x, digitz = 3) {
 #' kollapse
 #'
 #' Collapses values and strings to one string (without a white space). It also prints the results (good for a quick check)
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @param collapseby collapse elements into a string separated by this character
 #' @param print Print the results to the terminal. TRUE by default.
 #' @export
@@ -1896,7 +1896,7 @@ ww.set.mdlink <- function(NameOfaVariable="b.mdlink", def=FALSE) {  if( exists('
 #' ww.MarkDown_ImgLink_formatter
 #'
 #' Format a markdown image reference (link) from the file path to the file. It can parse the file path, if you pass it in separate variables and strings. E.g. ww.MarkDown_ImgLink_formatter(Directory, "MyImage.png").
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @export
 #' @examples ww.MarkDown_ImgLink_formatter (... =  )
 
@@ -2027,7 +2027,7 @@ setup_logging_markdown <- function (fname, title = "", append = T, b.png4Github 
 #' log_settings_MarkDown (OLD)
 #'
 #' Log the parameters & settings used in the script in a table format.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @export
 #' @examples log_settings_MarkDown (... =  )
 

--- a/MarkdownReports.LEGACY.VERSION.v3.1.2/R/MarkdownReports.R
+++ b/MarkdownReports.LEGACY.VERSION.v3.1.2/R/MarkdownReports.R
@@ -12,7 +12,7 @@ utils::globalVariables(c('OutDirOrig', 'OutDir', 'ParentDir', 'path_of_report', 
 # - Plots
 # - Plots for cycling over data frame columns or rows
 # - A4 pdfs for multi-plots
-# - Add-ons to exisiting plots
+# - Add-ons to existing plots
 # - Graphics
 # - Colors
 # - Printing to the markdown file and to the screen
@@ -180,7 +180,7 @@ setup_MarkdownReports <-
 #'
 #' Create or set the output directory of the script, and set the "NewOutDir" variable that is
 #' used by all ~wplot functions. Opening pair of the create_set_Original_OutDir function.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @param ParentDir Change the "OutDirOrig" variable to the
 #' current OutDir (before setting it to a subdir).
 #' @param define.ParentDir Report on what was the parent directory of the new subdir.
@@ -215,7 +215,7 @@ create_set_SubDir <-
       if (verbose) iprint("ParentDir will be:", OutDir)
       ww.assign_to_global("ParentDir", OutDir, 1)
     } #if
-    if (verbose) iprint("Call *create_set_Original_OutDir()* when chaning back to the main dir.")
+    if (verbose) iprint("Call *create_set_Original_OutDir()* when changing back to the main dir.")
     ww.assign_to_global("OutDir", NewOutDir, 1)
     ww.assign_to_global("b.Subdirname", b.Subdirname, 1)
     # Flag that md.image.linker uses
@@ -223,7 +223,7 @@ create_set_SubDir <-
 
 # create_set_Original_OutDir
 #'
-#' Closing pair of the create_set_SubDir function. Call when chaning back to the main dir.
+#' Closing pair of the create_set_SubDir function. Call when changing back to the main dir.
 #' Set the output directory of the script, and set the "NewOutDir" variable that is
 #'  used by all ~wplot functions.
 #'
@@ -282,7 +282,7 @@ continue_logging_markdown <- function (b.scriptname) {
 #' Create or set the output directory of the script, and set the "OutDir" variable that is used by
 #' all ~wplot functions.
 #'
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @param setDir Set the working directory to OutDir? Default: TRUE
 #' @param verbose Print directory to screen? Default: TRUE
 #'
@@ -2193,7 +2193,7 @@ pdfA4plot_off <- function () {
 
 
 
-# Add-ons to exisiting plots -----------------------------------------------------------------------
+# Add-ons to existing plots -----------------------------------------------------------------------
 
 #' error_bar
 #'
@@ -2260,10 +2260,10 @@ error_bar <-
 #' @param bty The type of box to be drawn around the legend.
 #' The allowed values are "o" (the default) and "n".
 #' @param title What should be the title of the legend? NULL by default
-#' @param ttl.by.varname Should the title of the legend substituted from the NamedColorVec variable's name?
-#' ALSE by default. Does not work if you pass on a list item like this: list$element
+#' @param ttl.by.varname Should the title of the legend be substituted from the NamedColorVec variable's name?
+#' FALSE by default. Does not work if you pass on a list item like this: list$element
 #' @param OverwritePrevPDF Save the plot immediately with the same name
-#' the last wplot* function made (It is stored in plotnameLastPlot variable).
+#' the last wplot* function made (It is stored in the plotnameLastPlot variable).
 #' @param mdlink Insert a .pdf and a .png image link in the markdown report
 #', set by "path_of_report".
 #' @export
@@ -2340,10 +2340,10 @@ wlegend <-
 #' @param bty The type of box to be drawn around the legend.
 #' The allowed values are "o" (the default) and "n".
 #' @param title What should be the title of the legend? NULL by default
-#' @param ttl.by.varname Should the title of the legend substituted from the NamedColorVec variable's name?
+#' @param ttl.by.varname Should the title of the legend be substituted from the NamedColorVec variable's name?
 #' FALSE by default. Does not work if you pass on a list item like this: list$element
 #' @param OverwritePrevPDF Save the plot immediately with the same name
-#' the last wplot* function made (It is stored in plotnameLastPlot variable).
+#' the last wplot* function made (It is stored in the plotnameLastPlot variable).
 #' @param mdlink Insert a .pdf and a .png image link in the markdown report,
 #' set by "path_of_report".
 #' @export
@@ -2393,14 +2393,14 @@ wlegend.label <-
 #' barplot_label
 #'
 #' Add extra labels to your bar plots at the top or the base.
-#' @param barplotted_variable The variable that you barplotted previously.
+#' @param barplotted_variable The variable that you previously bar plotted.
 #' @param labels Label text.
 #' @param bottom Put labels at the bottom of the bars.
-#' @param TopOffset Absolute offset from top.
-#' @param relpos_bottom Relative offset from bottom.
+#' @param TopOffset Absolute offset from the top.
+#' @param relpos_bottom Relative offset from the bottom.
 #' @param OverwritePrevPDF Save the plot immediately with the same name the last
-#' wplot* function made (It is stored in plotnameLastPlot variable). Never inserts an mdlink.
-#' @param filename Filename to overwrite after errorbars are added to the current barplot.
+#' wplot* function made (It is stored in the plotnameLastPlot variable). Never inserts an mdlink.
+#' @param filename Filename to overwrite after error bars are added to the current bar plot.
 #' @param PNG_ Set to true if you want to save the plot as PNG instead of the default PDF.
 #' @param w Width of the saved pdf image, in inches.
 #' @param h Height of the saved pdf image, in inches.
@@ -2449,17 +2449,17 @@ barplot_label <-
     }
   }
 
-#'wLinRegression
+#' @title wLinRegression
 #'
-#' Add linear regression, and descriptors to line to your scatter plot.
-#' Provide the same dataframe as you provided to wplot() before you called this function
-#' @param DF  The same dataframe as you provided to wplot() before you called this function
+#' Add linear regression and descriptors to a line in your scatter plot.
+#' Provide the same data frame as you provided to wplot() before calling this function
+#' @param DF  The same data frame that you provided to wplot() before calling this function
 #' @param coeff What coefficient to display? Either "all", "pearson", "spearman"
 #' correlation values or "r2" for the Coefficient of Determination.
-#' @param textlocation where to put the legend?
+#' @param textlocation Where to put the legend?
 #' @param cex font size; 1 by default
 #' @param OverwritePrevPDF Save the plot immediately with the same name the last
-#' wplot* function made (It is stored in plotnameLastPlot variable). Never inserts an mdlink.
+#' wplot* function made (It is stored in the plotnameLastPlot variable). Never inserts an mdlink.
 #' @param ...  Additional parameters for the line to display.
 #' @export
 #' @import stats
@@ -2669,7 +2669,7 @@ color_check <- function(..., incrBottMarginBy = 0, savefile = FALSE ) {
 #' iprint
 #'
 #' A more intelligent printing function that collapses any variable passed to it by white spaces.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @export
 #' @examples iprint ("Hello ", "you ", 3, ", ", 11, " year old kids.")
 
@@ -2685,7 +2685,7 @@ any_print = iprint # for compatibility
 #' Collapse by white spaces a sentence from any variable passed on to the function.
 #' Print the sentence to the screen and write it to your markdown report file,
 #' if the "path_of_report" variable is defined.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @export
 #' @examples MyFriends = c("Peter", "Bence"); llprint ("My friends are: ", MyFriends )
 
@@ -2706,7 +2706,7 @@ llprint <- function (...) {
 #' Collapse by white spaces a sentence from any variable passed on to the function.
 #' llogit() writes it to your markdown report file, if the "path_of_report" variable is defined.
 #' It does not print the sentence to the screen.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @export
 #' @examples MyFriends = c("Peter", "Bence"); llogit ("My friends are: ", MyFriends )
 
@@ -3108,12 +3108,12 @@ md.import.table <-
 #' Filter values that fall between above high-pass-threshold (X >).
 #' @param numeric_vector Values to be filtered.
 #' @param threshold A numeric value above which "numeric_vector" passes.
-#' @param passequal Pass if a value is larger, or equal than the threshold. FALSE by default.
+#' @param passequal Pass if a value is larger than or equal to the threshold. FALSE by default.
 #' @param prepend Text prepended to the results.
 #' @param return_survival_ratio Return a number with the survival ratio (TRUE),
 #'  or a logical index vector of the survivors (FALSE).
 #' @param plot.hist Plot the histogram of the input data
-#' @param saveplot Save the histogram as PDF, FALSE by defeault
+#' @param saveplot Save the histogram as PDF, FALSE by default
 #' @param na.rm Remove NA-s? Default: TRUE
 #' @param ... Additional arguments for the histogram
 #' @export
@@ -3178,12 +3178,12 @@ filter_HP <-
 #' Filter values that fall below the low-pass threshold (X <).
 #' @param numeric_vector Values to be filtered.
 #' @param threshold A numeric value below which "numeric_vector" passes.
-#' @param passequal Pass if a value is smaller, or equal than the threshold. FALSE by default.
+#' @param passequal Pass if a value is smaller than or equal to the threshold. FALSE by default.
 #' @param prepend Text prepended to the results.
 #' @param return_survival_ratio Return a number with the survival ratio (TRUE),
 #' or a logical index vector of the survivors (FALSE).
 #' @param plot.hist Plot the histogram of the input data
-#' @param saveplot Save the histogram as PDF, FALSE by defeault
+#' @param saveplot Save the histogram as PDF, FALSE by default
 #' @param na.rm Remove NA-s? Default: TRUE
 #' @param ... Additional arguments for the histogram
 #' @export
@@ -3247,7 +3247,7 @@ filter_LP <-
 #' @param EdgePass If TRUE, it reverses the filter:
 #' everything passes except between the two thresholds.
 #' @param plot.hist Plot the histogram of the input data
-#' @param saveplot Save the histogram as PDF, FALSE by defeault
+#' @param saveplot Save the histogram as PDF, FALSE by default
 #' @param na.rm Remove NA-s? Default: TRUE
 #' @param ... Additional arguments for the histogram
 #' @export
@@ -3418,7 +3418,7 @@ na.omit.strip <- function(object, silent = FALSE, ...) {
 #'
 #' Collapses values and strings to one string (without a white space).
 #' It also prints the results (good for a quick check)
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @param collapseby collapse elements into a string separated by this character
 #' @param print Print the results to the terminal. TRUE by default.
 #' @export
@@ -3753,7 +3753,7 @@ ww.set.mdlink <- function(NameOfaVariable = "b.mdlink",
 #' Format a markdown image reference (link) from the file path to the file.
 #' It can parse the file path, if you pass it in separate variables and strings.
 #' E.g. ww.md.image.link.parser(Directory, "MyImage.png").
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @export
 #' @examples ww.md.image.link.parser ("/MyPlot.jpg"  )
 #' ww.md.image.link.parser (getwd(),"/MyPlot.jpg"  )
@@ -3902,7 +3902,7 @@ setup_logging_markdown <-
 #' log_settings_MarkDown (Legacy)
 #'
 #' Log the parameters & settings used in the script in a table format.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @export
 #' @examples a = 1; b = 2; log_settings_MarkDown (a,b)
 

--- a/R/MarkdownReports.R
+++ b/R/MarkdownReports.R
@@ -14,8 +14,8 @@ utils::globalVariables(c(
 # - Plots
 # - Plots for cycling over data frame columns or rows
 # - A4 pdfs for multi-plots
-# - Add-ons to exisiting plots
-# - Graphics and Internal function
+# - Add-ons to existing plots
+# - Graphics and Internal functions
 
 
 # ______________________________________________________________________________________________----
@@ -204,11 +204,11 @@ setup_MarkdownReports <- function(OutDir = getwd(),
 #' @description Create or set the output directory of the script, and set the "OutDir" variable
 #' that is used by all ~wplot functions.
 #'
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @param setDir Set the working directory to OutDir? Default: TRUE
 #' @param verbose Print directory to screen? Default: TRUE
 #' @param newName Create a new variable with same path as the "OutDir" variable. Useful since
-#' OutDir may be redifined by other scripts
+#' OutDir may be redefined by other scripts
 #'
 #' @examples create_set_OutDir(setDir = TRUE, getwd())
 #' @export
@@ -234,7 +234,7 @@ create_set_OutDir <- function(..., setDir = TRUE, verbose = TRUE,
 #'
 #' @description Create or set the output directory of the script, and set the "NewOutDir" variable that is
 #' used by all ~wplot functions. Opening pair of the create_set_Original_OutDir function.
-#' @param ... Variables (strings, vectors) to be collapsed in consecutively.
+#' @param ... Variables (strings, vectors) to be collapsed consecutively.
 #' @param ParentDir Change the "OutDirOrig" variable to the
 #' current OutDir (before setting it to a subdir).
 #' @param define.ParentDir Report on what was the parent directory of the new subdir.
@@ -260,7 +260,7 @@ create_set_SubDir <- function(..., define.ParentDir = TRUE,
     setwd(NewOutDir)
   }
   if (define.ParentDir) {
-    if (exists("ParentDir")) { # If this function has been run already, you have "ParentDir", which will be overwritten.
+    if (exists("ParentDir")) { # If this function has already run, you have "ParentDir", which will be overwritten.
       if (verbose) {
         print("ParentDir was defined as:")
         message(ParentDir)
@@ -273,15 +273,15 @@ create_set_SubDir <- function(..., define.ParentDir = TRUE,
     }
     MarkdownHelpers::ww.assign_to_global("ParentDir", OutDir, 1)
   } # if
-  if (verbose) print("Call *create_set_Original_OutDir()* when chaning back to the main dir.")
+  if (verbose) print("Call *create_set_Original_OutDir()* when changing back to the main dir.")
   MarkdownHelpers::ww.assign_to_global("OutDir", NewOutDir, 1)
   MarkdownHelpers::ww.assign_to_global("b.Subdirname", b.Subdirname, 1)
-  # Flag that md.image.linker uses
+  # Flag used by md.image.linker
 }
 
 #' @title create_set_Original_OutDir
 #'
-#' @description Closing pair of the create_set_SubDir function. Call when chaning back to the main dir.
+#' @description Closing pair of the create_set_SubDir function. Call when changing back to the main dir.
 #' Set the output directory of the script, and set the "NewOutDir" variable that is
 #'  used by all ~wplot functions.
 #'
@@ -2369,7 +2369,7 @@ pdfA4plot_off <- function() {
 
 
 # ______________________________________________________________________________________________----
-# Add-ons to exisiting plots ----
+# Add-ons to existing plots ----
 # _________________________________________________________________________________________________
 
 
@@ -2433,10 +2433,10 @@ error_bar <- function(
 #' @param bty The type of box to be drawn around the legend.
 #' The allowed values are "o" (the default) and "n".
 #' @param title What should be the title of the legend? NULL by default
-#' @param ttl.by.varname Should the title of the legend substituted from the NamedColorVec variable's name?
-#' ALSE by default. Does not work if you pass on a list item like this: list$element
+#' @param ttl.by.varname Should the title of the legend be substituted from the NamedColorVec variable's name?
+#' FALSE by default. Does not work if you pass on a list item like this: list$element
 #' @param OverwritePrevPDF Save the plot immediately with the same name
-#' the last wplot* function made (It is stored in plotnameLastPlot variable).
+#' the last wplot* function made (It is stored in the plotnameLastPlot variable).
 #' @param mdlink Insert a .pdf and a .png image link in the markdown report
 #' , set by "path_of_report".
 #' @export
@@ -2505,7 +2505,7 @@ wlegend <- function(NamedColorVec = NA,
 
 #' @title wlegend.label
 #'
-#' @description Quickly add a "text only" legend without a filled color box. to an existing plot,
+#' @description Quickly add a "text only" legend without a filled color box to an existing plot,
 #' and save the plot immediately. Never inserts an mdlink.
 #' @param legend Labels displayed (Text)
 #' @param poz Position of the legend (def: 4). Use numbers 1-4 to choose from "topleft",
@@ -2517,10 +2517,10 @@ wlegend <- function(NamedColorVec = NA,
 #' @param bty The type of box to be drawn around the legend.
 #' The allowed values are "o" (the default) and "n".
 #' @param title What should be the title of the legend? NULL by default
-#' @param ttl.by.varname Should the title of the legend substituted from the NamedColorVec variable's name?
+#' @param ttl.by.varname Should the title of the legend be substituted from the NamedColorVec variable's name?
 #' FALSE by default. Does not work if you pass on a list item like this: list$element
 #' @param OverwritePrevPDF Save the plot immediately with the same name
-#' the last wplot* function made (It is stored in plotnameLastPlot variable).
+#' the last wplot* function made (It is stored in the plotnameLastPlot variable).
 #' @param mdlink Insert a .pdf and a .png image link in the markdown report,
 #' set by "path_of_report".
 #' @export
@@ -2538,7 +2538,7 @@ wlegend.label <- function(legend = "...",
                           ttl.by.varname = FALSE,
                           OverwritePrevPDF = unless.specified("b.save.wplots"),
                           mdlink = FALSE) {
-  w_ <- w # to avoid circular reference in the inside function argument
+  w_ <- w # to avoid a circular reference inside the function argument
   h_ <- h
   cex_ <- cex
 
@@ -2569,14 +2569,14 @@ wlegend.label <- function(legend = "...",
 #' @title barplot_label
 #'
 #' @description Add extra labels to your bar plots at the top or the base.
-#' @param barplotted_variable The variable that you barplotted previously.
+#' @param barplotted_variable The variable that you previously bar plotted.
 #' @param labels Label text.
 #' @param bottom Put labels at the bottom of the bars.
-#' @param TopOffset Absolute offset from top.
-#' @param relpos_bottom Relative offset from bottom.
+#' @param TopOffset Absolute offset from the top.
+#' @param relpos_bottom Relative offset from the bottom.
 #' @param OverwritePrevPDF Save the plot immediately with the same name the last
-#' wplot* function made (It is stored in plotnameLastPlot variable). Never inserts an mdlink.
-#' @param filename Filename to overwrite after errorbars are added to the current barplot.
+#' wplot* function made (It is stored in the plotnameLastPlot variable). Never inserts an mdlink.
+#' @param filename Filename to overwrite after error bars are added to the current bar plot.
 #' @param PNG_ Set to true if you want to save the plot as PNG instead of the default PDF.
 #' @param w Width of the saved pdf image, in inches.
 #' @param h Height of the saved pdf image, in inches.
@@ -2623,15 +2623,15 @@ barplot_label <- function(barplotted_variable,
 
 #' @title wLinRegression
 #'
-#' @description Add linear regression, and descriptors to line to your scatter plot.
-#' Provide the same dataframe as you provided to wplot() before you called this function
-#' @param DF  The same dataframe as you provided to wplot() before you called this function
+#' @description Add linear regression and descriptors to a line in your scatter plot.
+#' Provide the same data frame as you provided to wplot() before calling this function
+#' @param DF  The same data frame that you provided to wplot() before calling this function
 #' @param coeff What coefficient to display? Either "all", "pearson", "spearman"
 #' correlation values or "r2" for the Coefficient of Determination.
-#' @param textlocation where to put the legend?
+#' @param textlocation Where to put the legend?
 #' @param cex font size; 1 by default
 #' @param OverwritePrevPDF Save the plot immediately with the same name the last
-#' wplot* function made (It is stored in plotnameLastPlot variable). Never inserts an mdlink.
+#' wplot* function made (It is stored in the plotnameLastPlot variable). Never inserts an mdlink.
 #' @param ...  Additional parameters for the line to display.
 #' @export
 #' @import stats


### PR DESCRIPTION
## Summary
- correct spelling and grammar in inline comments for main and legacy R sources

## Testing
- `R CMD build .` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893356849ec832cbe1c3149725cb6f9