### PR TITLE
fix: correct spelling mistakes

### DIFF
--- a/Development/Development.bac
+++ b/Development/Development.bac
@@ -14,7 +14,7 @@ utils::globalVariables(c(
 # - Plots
 # - Plots for cycling over data frame columns or rows
 # - A4 pdfs for multi-plots
-# - Add-ons to exisiting plots
+# - Add-ons to existing plots
 # - Graphics and Internal function
 
 
@@ -2293,7 +2293,7 @@ pdfA4plot_off <- function() {
 
 
 # ______________________________________________________________________________________________----
-# Add-ons to exisiting plots ----
+# Add-ons to existing plots ----
 # _________________________________________________________________________________________________
 
 

--- a/Development/Flowcharts.in.R.with.mermaid.in.DiagrameR/n_2018_08_02-14h/1.html
+++ b/Development/Flowcharts.in.R.with.mermaid.in.DiagrameR/n_2018_08_02-14h/1.html
@@ -811,7 +811,7 @@
 
   // Takes a new-style instance-bound definition, and returns an
   // old-style class-bound definition. This saves us from having
-  // to rewrite all the logic in this file to accomodate both
+  // to rewrite all the logic in this file to accommodate both
   // types of definitions.
   function createLegacyDefinitionAdapter(defn) {
     var result = {

--- a/Development/Flowcharts.in.R.with.mermaid.in.DiagrameR/n_2018_08_02-14h/11.html
+++ b/Development/Flowcharts.in.R.with.mermaid.in.DiagrameR/n_2018_08_02-14h/11.html
@@ -811,7 +811,7 @@
 
   // Takes a new-style instance-bound definition, and returns an
   // old-style class-bound definition. This saves us from having
-  // to rewrite all the logic in this file to accomodate both
+  // to rewrite all the logic in this file to accommodate both
   // types of definitions.
   function createLegacyDefinitionAdapter(defn) {
     var result = {

--- a/MarkdownReports.LEGACY.VERSION.v3.1.1/R/MarkdownReports.R
+++ b/MarkdownReports.LEGACY.VERSION.v3.1.1/R/MarkdownReports.R
@@ -4,14 +4,14 @@
 # source("~/GitHub/MarkdownReports/MarkdownReports/R/MarkdownReports.R")
 
 
-# Dependecies:  stats, vioplot, colorRamps, gplots, VennDiagram,
+# Dependencies:  stats, vioplot, colorRamps, gplots, VennDiagram,
 
 # Table of Contents ------------------------------------
 # - Setup
 # - Plots
 # - Plots for cycling over data frame columns or rows
 # - A4 pdfs for multi-plots
-# - Add-ons to exisiting plots
+# - Add-ons to existing plots
 # - Graphics
 # - Colors
 # - Printing to the markdown file and to the screen
@@ -1073,7 +1073,7 @@ pdfA4plot_off <- function () {
 
 
 
-# Add-ons to exisiting plots -------------------------------------------------------------------------------------------------
+# Add-ons to existing plots -------------------------------------------------------------------------------------------------
 
 #' error_bar
 #'
@@ -1506,13 +1506,13 @@ md.import <- function(from.file, to.file = path_of_report) {
 #' md.LogSettingsFromList
 #'
 #' Log the parameters & settings used in the script and stored in a list, in a table format in the report.
-#' @param parameterlist List of Paramters
+#' @param parameterlist List of Parameters
 #' @param maxlen Maximum length of entries in a parameter list element
 #' @export
 #' @examples md.LogSettingsFromList(parameterlist = list("min"=4, "method"="pearson", "max"=10))
 
 md.LogSettingsFromList <- function (parameterlist=px, maxlen =20) {
-  LZ = unlapply(parameterlist, length) # collapse paramters with multiple entires
+  LZ = unlapply(parameterlist, length) # collapse parameters with multiple entries
   LNG = names(which(LZ>1))
   for (i in LNG ) {
     if (length(parameterlist[[i]]) > maxlen) parameterlist[[i]] = parameterlist[[i]][1:maxlen]
@@ -1820,7 +1820,7 @@ getCategories <- function(named_categ_vec) { named_categ_vec[unique(names(named_
 #' parFlags
 #'
 #' Create a string from the names of the (boolean) parameters (T or F) of true values. Use it for Suffixing plot names with the parameters that were used for that plot.
-#' @param ... Paramter variables
+#' @param ... Parameter variables
 #' @param prefix Append something before?
 #' @param pasteflg Boolean: paste the parameters-flags together?
 #' @param collapsechar Separating character between each parameters-flag
@@ -1839,7 +1839,7 @@ parFlags <- function(prefix="", ..., pasteflg=T, collapsechar =".") {
 #' parFlags2
 #'
 #' Create a string from the names of the (boolean) parameters (T or F) of true values. Use it for Suffixing plot names with the parameters that were used for that plot.
-#' @param ... Paramter variables
+#' @param ... Parameter variables
 #' @param prefix Append something before?
 #' @param pasteflg Boolean: paste the parameters-flags together?
 #' @param coll.char Separating character between each parameters-flag

--- a/MarkdownReports.LEGACY.VERSION.v3.1.1/man/md.LogSettingsFromList.Rd
+++ b/MarkdownReports.LEGACY.VERSION.v3.1.1/man/md.LogSettingsFromList.Rd
@@ -7,7 +7,7 @@
 md.LogSettingsFromList(parameterlist = px, maxlen = 20)
 }
 \arguments{
-\item{parameterlist}{List of Paramters}
+\item{parameterlist}{List of Parameters}
 
 \item{maxlen}{Maximum length of entries in a parameter list element}
 }

--- a/MarkdownReports.LEGACY.VERSION.v3.1.1/man/parFlags.Rd
+++ b/MarkdownReports.LEGACY.VERSION.v3.1.1/man/parFlags.Rd
@@ -9,7 +9,7 @@ parFlags(prefix = "", ..., pasteflg = T, collapsechar = ".")
 \arguments{
 \item{prefix}{Append something before?}
 
-\item{...}{Paramter variables}
+\item{...}{Parameter variables}
 
 \item{pasteflg}{Boolean: paste the parameters-flags together?}
 

--- a/MarkdownReports.LEGACY.VERSION.v3.1.1/man/parFlags2.Rd
+++ b/MarkdownReports.LEGACY.VERSION.v3.1.1/man/parFlags2.Rd
@@ -10,7 +10,7 @@ parFlags2(prefix = ".", ..., pasteflg = T, coll.char = ".",
 \arguments{
 \item{prefix}{Append something before?}
 
-\item{...}{Paramter variables}
+\item{...}{Parameter variables}
 
 \item{pasteflg}{Boolean: paste the parameters-flags together?}
 

--- a/MarkdownReports.LEGACY.VERSION.v3.1.2/R/MarkdownReports.R
+++ b/MarkdownReports.LEGACY.VERSION.v3.1.2/R/MarkdownReports.R
@@ -12,7 +12,7 @@ utils::globalVariables(c('OutDirOrig', 'OutDir', 'ParentDir', 'path_of_report', 
 # - Plots
 # - Plots for cycling over data frame columns or rows
 # - A4 pdfs for multi-plots
-# - Add-ons to exisiting plots
+# - Add-ons to existing plots
 # - Graphics
 # - Colors
 # - Printing to the markdown file and to the screen
@@ -2193,7 +2193,7 @@ pdfA4plot_off <- function () {
 
 
 
-# Add-ons to exisiting plots -----------------------------------------------------------------------
+# Add-ons to existing plots -----------------------------------------------------------------------
 
 #' error_bar
 #'
@@ -2885,14 +2885,14 @@ md.import <- function(from.file, to.file = path_of_report) {
 #'
 #' Log the parameters & settings used in the script and stored in a list, in a table format
 #'  in the report.
-#' @param parameterlist List of Paramters
+#' @param parameterlist List of Parameters
 #' @param maxlen Maximum length of entries in a parameter list element
 #' @export
 #' @examples md.LogSettingsFromList(parameterlist = list("min" = 4, "method" = "pearson", "max" = 10))
 
 md.LogSettingsFromList <- function (parameterlist,
                                     maxlen = 20) {
-  LZ = unlist(lapply(parameterlist, length)) # collapse paramters with multiple entires
+  LZ = unlist(lapply(parameterlist, length)) # collapse parameters with multiple entries
   LNG = names(which(LZ > 1))
   for (i in LNG) {
     if (length(parameterlist[[i]]) > maxlen)
@@ -3510,7 +3510,7 @@ getCategories <-
 #'
 #' Create a string from the names of the (boolean) parameters (TRUE or FALSE) of true values.
 #' Use it for Suffixing plot names with the parameters that were used for that plot.
-#' @param ... Paramter variables
+#' @param ... Parameter variables
 #' @param prefix Append something before?
 #' @param pasteflg Boolean: paste the parameters-flags together?
 #' @param collapsechar Separating character between each parameters-flag
@@ -3538,7 +3538,7 @@ parFlags <-
 #'
 #' Create a string from the names of the (boolean) parameters (TRUE or FALSE) of true values.
 #' Use it for Suffixing plot names with the parameters that were used for that plot.
-#' @param ... Paramter variables
+#' @param ... Parameter variables
 #' @param prefix Append something before?
 #' @param pasteflg Boolean: paste the parameters-flags together?
 #' @param coll.char Separating character between each parameters-flag

--- a/MarkdownReports.LEGACY.VERSION.v3.1.2/man/md.LogSettingsFromList.Rd
+++ b/MarkdownReports.LEGACY.VERSION.v3.1.2/man/md.LogSettingsFromList.Rd
@@ -7,7 +7,7 @@
 md.LogSettingsFromList(parameterlist = px, maxlen = 20)
 }
 \arguments{
-\item{parameterlist}{List of Paramters}
+\item{parameterlist}{List of Parameters}
 
 \item{maxlen}{Maximum length of entries in a parameter list element}
 }

--- a/MarkdownReports.LEGACY.VERSION.v3.1.2/man/parFlags.Rd
+++ b/MarkdownReports.LEGACY.VERSION.v3.1.2/man/parFlags.Rd
@@ -9,7 +9,7 @@ parFlags(prefix = "", ..., pasteflg = T, collapsechar = ".")
 \arguments{
 \item{prefix}{Append something before?}
 
-\item{...}{Paramter variables}
+\item{...}{Parameter variables}
 
 \item{pasteflg}{Boolean: paste the parameters-flags together?}
 

--- a/MarkdownReports.LEGACY.VERSION.v3.1.2/man/parFlags2.Rd
+++ b/MarkdownReports.LEGACY.VERSION.v3.1.2/man/parFlags2.Rd
@@ -10,7 +10,7 @@ parFlags2(prefix = ".", ..., pasteflg = T, coll.char = ".",
 \arguments{
 \item{prefix}{Append something before?}
 
-\item{...}{Paramter variables}
+\item{...}{Parameter variables}
 
 \item{pasteflg}{Boolean: paste the parameters-flags together?}
 

--- a/R/MarkdownReports.R
+++ b/R/MarkdownReports.R
@@ -14,7 +14,7 @@ utils::globalVariables(c(
 # - Plots
 # - Plots for cycling over data frame columns or rows
 # - A4 pdfs for multi-plots
-# - Add-ons to exisiting plots
+# - Add-ons to existing plots
 # - Graphics and Internal function
 
 
@@ -2369,7 +2369,7 @@ pdfA4plot_off <- function() {
 
 
 # ______________________________________________________________________________________________----
-# Add-ons to exisiting plots ----
+# Add-ons to existing plots ----
 # _________________________________________________________________________________________________
 
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ and your report will have the summary: ***30.7 % or 614 of 2000 entries in GeneE
   - Native **2-D error bars** in scatterplots`wplot()` .
   - Easy **colour schemes** by `wcolorize()` from  `base`, `gplots` and `Rcolorbrewer`.
   - Add **legends** with the super short command `wlegend(colannot$categ)`, defining colors named after the categories of your data.
-    - It is autmatically created by `colannot = wcolorize(your.annotation, ReturnCategoriesToo = T)`, which you (can) anyways use to colour data points on, say, your scatterplot.
+    - It is automatically created by `colannot = wcolorize(your.annotation, ReturnCategoriesToo = T)`, which you (can) anyways use to colour data points on, say, your scatterplot.
   - **Show filtering results with a one liner**: `whist(rnorm(1000), vline = .5, filtercol = T)`.
 - *Although **currently** plotting is implemented as an enhanced **base graphic**, but the concept could easily be extended to **ggplot**.*
   Yet, you can still use ggplot, because you equally well save and report them by either `wplot_save_this()` or the `pdfA4plot_on()` and `pdfA4plot_off()` functions.


### PR DESCRIPTION
## Summary
- fix typos like "autmatically" and "accomodate"
- correct "exisiting" references in scripts
- standardize parameter-related wording in legacy code and docs

## Testing
- `R CMD build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68948bce89e4832ca17fc8c2346e12ce