### PR TITLE
Add missing dependency on "checkmate" package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     RColorBrewer,
     ReadWriter,
     VennDiagram,
+    checkmate,
     clipr,
     colorRamps,
     gplots,


### PR DESCRIPTION
I couldn't install MarkdownReports because I didn't have checkmate installed.

Thank you for all of your work on this and other packages!