### PR TITLE
Fix minor typos in MarkdownReports documentation

### DIFF
--- a/R/MarkdownReports.R
+++ b/R/MarkdownReports.R
@@ -175,7 +175,6 @@ setup_MarkdownReports <- function(OutDir = getwd(),
     dir.create(BackupDir, showWarnings = FALSE)
     MarkdownHelpers::ww.assign_to_global("BackupDir", BackupDir, 1, verbose = FALSE)
   }
-  saveParameterList
   if (saveParameterList != FALSE) {
     print("")
     print("PARAMETER LIST ---------------------------")
@@ -2029,7 +2028,7 @@ wviostripchart_list <- function(yourlist,
 
 #' @title wvenn
 #'
-#' @description Save venn diagrams. Unlike other ~vplot funcitons, this saves directly into a .png,
+#' @description Save venn diagrams. Unlike other ~vplot functions, this saves directly into a .png,
 #' and it does not use the dev.copy2pdf() function.
 #' @param yourlist The variable to plot.
 #' @param imagetype Image format, png by default.


### PR DESCRIPTION
## Summary
- remove a stray no-op statement from setup_MarkdownReports parameter handling
- fix a spelling error in the wvenn documentation string

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ef484b83c83238b99bc1213c6b7c9)