### PR TITLE
Improve column name clarity in wscatter.fill

### DIFF
--- a/R/MarkdownReports.R
+++ b/R/MarkdownReports.R
@@ -765,12 +765,12 @@ wscatter.fill <- function(df2col = cbind("A" = rnorm(100), "B" = rnorm(100)),
                           PNG = unless.specified("b.usepng", FALSE)) {
   x <- df2col[, 1]
   y <- df2col[, 2]
-  CNN <- colnames(df2col)
-  xlab <- if (length(CNN) & missing(xlab)) {
-    CNN[1]
+  col_names <- colnames(df2col)
+  xlab <- if (length(col_names) & missing(xlab)) {
+    col_names[1]
   }
-  ylab <- if (length(CNN) & missing(ylab)) {
-    CNN[2]
+  ylab <- if (length(col_names) & missing(ylab)) {
+    col_names[2]
   }
 
   fname <- kollapse(plotname, ".scatter.fill")


### PR DESCRIPTION
## Summary
- rename the ambiguous `CNN` helper variable to clearer `col_names` in `wscatter.fill`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692efaa86dcc8323a02310aee089c533)